### PR TITLE
Split administer media permission

### DIFF
--- a/media_entity.permissions.yml
+++ b/media_entity.permissions.yml
@@ -1,6 +1,9 @@
 administer media:
   title: 'Administer media'
   restrict access: TRUE
+administer media types:
+  title: 'Administer media types'
+  restrict access: TRUE
 view media:
   title: 'View media'
 update media:

--- a/media_entity.routing.yml
+++ b/media_entity.routing.yml
@@ -51,21 +51,21 @@ entity.media_bundle.collection:
     _entity_list: 'media_bundle'
     _title: 'Media bundles'
   requirements:
-    _permission: 'administer media'
+    _permission: 'administer media types'
 
 media.bundle_add:
   path: '/admin/structure/media/add'
   defaults:
     _entity_form: 'media_bundle.add'
   requirements:
-    _permission: 'administer media'
+    _permission: 'administer media types'
 
 entity.media_bundle.edit_form:
   path: '/admin/structure/media/manage/{media_bundle}'
   defaults:
     _entity_form: 'media_bundle.edit'
   requirements:
-    _permission: 'administer media'
+    _permission: 'administer media types'
 
 entity.media_bundle.delete_form:
   path: '/admin/structure/media/manage/{media_bundle}/delete'
@@ -73,4 +73,4 @@ entity.media_bundle.delete_form:
     _entity_form: 'media_bundle.delete'
     _title: 'Delete'
   requirements:
-    _permission: 'administer media'
+    _permission: 'administer media types'

--- a/src/Entity/MediaBundle.php
+++ b/src/Entity/MediaBundle.php
@@ -27,7 +27,7 @@ use Drupal\media_entity\MediaInterface;
  *     },
  *     "list_builder" = "Drupal\media_entity\MediaBundleListBuilder",
  *   },
- *   admin_permission = "administer media",
+ *   admin_permission = "administer media types",
  *   config_prefix = "bundle",
  *   bundle_of = "media",
  *   entity_keys = {

--- a/src/Tests/MediaUITest.php
+++ b/src/Tests/MediaUITest.php
@@ -40,9 +40,7 @@ class MediaUITest extends MediaEntityTestBase {
 
     $this->adminUser = $this->drupalCreateUser(array(
       'administer media',
-      'administer media fields',
-      'administer media form display',
-      'administer media display',
+      'administer media types',
       // Media entity permissions.
       'view media',
       'create media',


### PR DESCRIPTION
The "administer media" is very powerful atm. I think we should split the permission in two similar to node module.
