### PR TITLE
Expose Media publisher to Field UI

### DIFF
--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -294,7 +294,18 @@ class Media extends ContentEntityBase implements MediaInterface {
         'type' => 'author',
         'weight' => 0,
       ))
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('form', array(
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 5,
+        'settings' => array(
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ),
+      ))
+      ->setDisplayConfigurable('form', TRUE);
 
     $fields['status'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Publishing status'))


### PR DESCRIPTION
I think this is a regression after #35 got in. It is currently not possible to set the publisher from the user interface.
