### PR TITLE
Bundle try/catch is unnecessary?

### DIFF
--- a/src/MediaForm.php
+++ b/src/MediaForm.php
@@ -139,7 +139,7 @@ class MediaForm extends ContentEntityForm {
     $entity = parent::validateForm($form, $form_state);
 
     /** @var \Drupal\media_entity\MediaBundleInterface $bundle */
-    $bundle = $this->entityManager->getStorage('media_bundle')->load($entity->bundle());
+    /**$bundle = $this->entityManager->getStorage('media_bundle')->load($entity->bundle());
     if ($type = $bundle->getType()) {
       try {
         $type->validate($entity);
@@ -147,7 +147,7 @@ class MediaForm extends ContentEntityForm {
       catch (MediaTypeException $e) {
         $form_state->setErrorByName($e->getElement(), $e->getMessage());
       }
-    }
+    }*/
 
   }
 


### PR DESCRIPTION
Unsure why this is showing a null error during Media Entity save. If I remove it, the Media entity saves correctly.
