### PR TITLE
Add a trait for easy extraction of embed codes

### DIFF
--- a/src/EmbedCodeValueTrait.php
+++ b/src/EmbedCodeValueTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\media_entity\EmbedCodeValueTrait.
+ */
+
+namespace Drupal\media_entity;
+
+use Drupal\Core\Field\FieldItemInterface;
+
+/**
+ * A trait to assist with handling external embed codes.
+ */
+trait EmbedCodeValueTrait {
+
+  /**
+   * Extracts the raw embed code from input which may or may not be wrapped.
+   *
+   * @param mixed $value
+   *   The input value. Can be a normal string or a value wrapped by the
+   *   Typed Data API.
+   *
+   * @return string|null
+   */
+  protected function getEmbedCode($value) {
+    if (is_string($value)) {
+      return $value;
+    }
+    elseif ($value instanceof FieldItemInterface) {
+      $class = $value->getFieldDefinition()->getClass();
+      $property = $class::mainPropertyName();
+      if ($property) {
+        return $value->get($property);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This generalizes the functionality added in drupal-media/media_entity_instagram#17 and drupal-media/media_entity_twitter#18. It provides a trait which will help validators, formatters, etc. extract embed codes from various wrappers (field items, primitive Typed Data wrappers, or what have you).
