### PR TITLE
EmbedCodeValueTrait::getValue() causes a fatal error

### DIFF
--- a/src/EmbedCodeValueTrait.php
+++ b/src/EmbedCodeValueTrait.php
@@ -28,10 +28,10 @@ trait EmbedCodeValueTrait {
       return $value;
     }
     elseif ($value instanceof FieldItemInterface) {
-      $class = $value->getFieldDefinition()->getClass();
+      $class = get_class($value);
       $property = $class::mainPropertyName();
       if ($property) {
-        return $value->get($property);
+        return $value->$property;
       }
     }
   }


### PR DESCRIPTION
The method does an improper job of extracting the main property name from the field definition, which will almost always result in a fatal error when getValue() is actually called. ("Undefined method mainPropertyName()".)

This fixes the problem. It may break tests in media_entity_twitter and media_entity_instagram, but I will file PRs against those to update their tests.
