### PR TITLE
Add  parameter to MediaTestTrait

### DIFF
--- a/src/Tests/MediaTestTrait.php
+++ b/src/Tests/MediaTestTrait.php
@@ -28,10 +28,14 @@ trait MediaTestTrait {
    * @param array $values
    *   The media bundle values.
    *
+   * @param string $type_name
+   *   (optional) The media type provider plugin that is responsible for
+   *   additional logic related to this media).
+   *
    * @return \Drupal\Core\Entity\EntityInterface
    *   Returns newly created media bundle.
    */
-  protected function drupalCreateMediaBundle(array $values = array()) {
+  protected function drupalCreateMediaBundle(array $values = array(), $type_name = 'generic') {
     if (!isset($values['bundle'])) {
       $id = strtolower($this->randomMachineName());
     }
@@ -41,7 +45,7 @@ trait MediaTestTrait {
     $values += array(
       'id' => $id,
       'label' => $id,
-      'type' => 'generic',
+      'type' => $type_name,
       'type_configuration' => array(),
       'field_map' => array(),
     );


### PR DESCRIPTION
Now we have createMediaBundle() in InstagramEmbedFormatterTest and TweetEmbedFormatterTest which is not so pretty.
As discussed with @slashrsm it would make sense to have everything in one place.

Here I have added $type_name parameter in MediaTestTrait::drupalCreateMediaBundle() so that we can change the media type provider plugin for the related test calling this method.
