### PR TITLE
The 'create media' permission is not supported

### DIFF
--- a/src/MediaAccessController.php
+++ b/src/MediaAccessController.php
@@ -28,6 +28,9 @@ class MediaAccessController extends EntityAccessControlHandler {
 
     $is_owner = ($account->id() && $account->id() == $entity->getPublisherId()) ? TRUE : FALSE;
     switch ($operation) {
+      case 'create':
+        return AccessResult::allowedIfHasPermission($account, 'create media');
+
       case 'view':
         return AccessResult::allowedIfHasPermission($account, 'view media');
 

--- a/tests/src/Unit/MediaAccessControllerTest.php
+++ b/tests/src/Unit/MediaAccessControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\media_entity\Unit\MediaAccessControllerTest.
+ */
+
+namespace Drupal\Tests\media_entity\Unit;
+
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\media_entity\MediaAccessController;
+use Drupal\media_entity\MediaInterface;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+
+/**
+ * @group media_entity
+ */
+class MediaAccessControllerTest extends UnitTestCase {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeInterface
+   */
+  protected $entityType;
+
+  /**
+   * @var \Drupal\media_entity\MediaAccessController
+   */
+  protected $accessController;
+
+  protected function setUp() {
+    $this->entityType = $this->prophesize(EntityTypeInterface::class);
+    $this->entityType->id()->willReturn('media');
+    $this->accessController = new TestMediaAccessController($this->entityType->reveal());
+
+    // MediaAccessController::checkAccess() will call cachePerPermission() on
+    // the access result, which in turn will access the non-injected
+    // cache_contexts_manager service and assert the result of its
+    // assertValidTokens() method. So we set that up to always return TRUE.
+    $container = new ContainerBuilder();
+    $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
+    $cache_contexts_manager->assertValidTokens(Argument::any())->willReturn(TRUE);
+    $container->set('cache_contexts_manager', $cache_contexts_manager->reveal());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Tests
+   */
+  public function testCreateAccessNotAdministrator() {
+    $entity = $this->prophesize(MediaInterface::class);
+    $entity->getPublisherId()->willReturn(42);
+
+    $account = $this->prophesize(AccountInterface::class);
+    $account->id()->willReturn(42);
+    $account->hasPermission('administer media')->willReturn(FALSE);
+    $account->hasPermission('create media')->willReturn(TRUE);
+
+    $result = $this->accessController->checkAccess($entity->reveal(), 'create', $account->reveal());
+    $this->assertInstanceOf(AccessResultAllowed::class, $result);
+  }
+
+}
+
+class TestMediaAccessController extends MediaAccessController {
+
+  public function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    return parent::checkAccess($entity, $operation, $account);
+  }
+
+}

--- a/tests/src/Unit/MediaAccessControllerTest.php
+++ b/tests/src/Unit/MediaAccessControllerTest.php
@@ -24,11 +24,15 @@ use Prophecy\Argument;
 class MediaAccessControllerTest extends UnitTestCase {
 
   /**
+   * The mocked entity type definition.
+   *
    * @var \Drupal\Core\Entity\EntityTypeInterface
    */
   protected $entityType;
 
   /**
+   * The media entity access controller.
+   *
    * @var \Drupal\media_entity\MediaAccessController
    */
   protected $accessController;
@@ -50,17 +54,22 @@ class MediaAccessControllerTest extends UnitTestCase {
   }
 
   /**
-   * Tests
+   * Tests that users with the 'create media' permission (but not the
+   * 'administer media' permission) actually have proper permission to create
+   * media entities.
    */
   public function testCreateAccessNotAdministrator() {
     $entity = $this->prophesize(MediaInterface::class);
     $entity->getPublisherId()->willReturn(42);
 
+    // Mock a user account with the permission to create, but not administer,
+    // media entities.
     $account = $this->prophesize(AccountInterface::class);
     $account->id()->willReturn(42);
     $account->hasPermission('administer media')->willReturn(FALSE);
     $account->hasPermission('create media')->willReturn(TRUE);
 
+    // Ensure that the access controller will grant create access.
     $result = $this->accessController->checkAccess($entity->reveal(), 'create', $account->reveal());
     $this->assertInstanceOf(AccessResultAllowed::class, $result);
   }

--- a/tests/src/Unit/MediaAccessControllerTest.php
+++ b/tests/src/Unit/MediaAccessControllerTest.php
@@ -37,6 +37,9 @@ class MediaAccessControllerTest extends UnitTestCase {
    */
   protected $accessController;
 
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     $this->entityType = $this->prophesize(EntityTypeInterface::class);
     $this->entityType->id()->willReturn('media');
@@ -54,7 +57,9 @@ class MediaAccessControllerTest extends UnitTestCase {
   }
 
   /**
-   * Tests that users with the 'create media' permission (but not the
+   * Tests the 'create media' permission.
+   *
+   * Ensures that users with the 'create media' permission (but not the
    * 'administer media' permission) actually have proper permission to create
    * media entities.
    */
@@ -76,8 +81,14 @@ class MediaAccessControllerTest extends UnitTestCase {
 
 }
 
+/**
+ * Test-only version of MediaAccessController, for testing protected methods.
+ */
 class TestMediaAccessController extends MediaAccessController {
 
+  /**
+   * {@inheritdoc}
+   */
   public function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
     return parent::checkAccess($entity, $operation, $account);
   }


### PR DESCRIPTION
Users with the 'create media' permission receive a 403 error when they try to create a media entity. It looks as though MediaAccessController does not provide any support for the permission. This PR fixes that, and adds a test.

https://www.drupal.org/node/2630456
