### PR TITLE
Added fieldset to allow translation of media bundle content

### DIFF
--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -251,9 +251,17 @@ class Media extends ContentEntityBase implements MediaInterface {
       ->setReadOnly(TRUE);
 
     $fields['langcode'] = BaseFieldDefinition::create('language')
-      ->setLabel(t('Language code'))
+      ->setLabel(t('Language'))
       ->setDescription(t('The media language code.'))
-      ->setRevisionable(TRUE);
+      ->setTranslatable(TRUE)
+      ->setRevisionable(TRUE)
+      ->setDisplayOptions('view', array(
+        'type' => 'hidden',
+      ))
+      ->setDisplayOptions('form', array(
+        'type' => 'language_select',
+        'weight' => 2,
+      ));
 
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Media name'))

--- a/src/MediaBundleForm.php
+++ b/src/MediaBundleForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\language\Entity\ContentLanguageSettings;
 use Drupal\media_entity\MediaTypeManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -132,6 +133,25 @@ class MediaBundleForm extends EntityForm {
       $form['type_configuration'][$plugin] += $instance->buildConfigurationForm([], $form_state);
       // Store the instance for validate and submit handlers.
       $this->configurableInstances[$plugin] = $instance;
+    }
+
+    if ($this->moduleHandler->moduleExists('language')) {
+      $form['language'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Language settings'),
+        '#group' => 'additional_settings',
+      );
+
+      $language_configuration = ContentLanguageSettings::loadByEntityTypeBundle('media', $bundle->id());
+
+      $form['language']['language_configuration'] = array(
+        '#type' => 'language_configuration',
+        '#entity_information' => array(
+          'entity_type' => 'media',
+          'bundle' => $bundle->id(),
+        ),
+        '#default_value' => $language_configuration,
+      );
     }
 
     return $form;


### PR DESCRIPTION
I added the form elements needed to configure translation for bundles. Did some manual testing and it seems to work great.

The checkbox for `Show language selector on create and edit pages` does not seem to have any impact on the create/edit media pages even tough the Translation field is visible on Manage form display for the bundle.

I decided to use a fieldset to have it comply with the type provider configuration.

Issue on Drupal.org:
https://www.drupal.org/node/2661066#comment-10813230
