### PR TITLE
Bundlerevisionauto

### DIFF
--- a/config/schema/media_entity.schema.yml
+++ b/config/schema/media_entity.schema.yml
@@ -22,6 +22,9 @@ media_entity.bundle.*:
     type:
       type: string
       label: 'Type plugin ID'
+    new_revision:
+      type: boolean
+      label: 'Whether a new revision should be created by default'
     third_party_settings:
       type: sequence
       label: 'Third party settings'

--- a/src/Entity/MediaBundle.php
+++ b/src/Entity/MediaBundle.php
@@ -39,6 +39,7 @@ use Drupal\media_entity\MediaInterface;
  *     "label",
  *     "description",
  *     "type",
+ *     "new_revision",
  *     "third_party_settings",
  *     "type_configuration",
  *     "field_map",
@@ -79,6 +80,13 @@ class MediaBundle extends ConfigEntityBundleBase implements MediaBundleInterface
    * @var string
    */
   public $type = 'generic';
+
+  /**
+   * Default value of the 'Create new revision' checkbox of this media bundle.
+   *
+   * @var bool
+   */
+  protected $new_revision = FALSE;
 
   /**
    * The type plugin configuration.
@@ -172,6 +180,20 @@ class MediaBundle extends ConfigEntityBundleBase implements MediaBundleInterface
       $this->typePluginCollection = new DefaultSingleLazyPluginCollection(\Drupal::service('plugin.manager.media_entity.type'), $this->type, $this->type_configuration);
     }
     return $this->typePluginCollection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isNewRevision() {
+    return $this->new_revision;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setNewRevision($new_revision) {
+    $this->new_revision = $new_revision;
   }
 
 }

--- a/src/MediaBundleForm.php
+++ b/src/MediaBundleForm.php
@@ -154,8 +154,14 @@ class MediaBundleForm extends EntityForm {
       );
     }
 
-    return $form;
-  }
+    $form['new_revision'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Create new revision'),
+      '#default_value' => $bundle->isNewRevision(),
+    ];
+
+     return $form;
+   }
 
   /**
    * {@inheritdoc}
@@ -209,6 +215,7 @@ class MediaBundleForm extends EntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     /** @var  \Drupal\media_entity\MediaBundleInterface $bundle */
     $bundle = $this->entity;
+    $bundle->setNewRevision($form_state->getValue('new_revision'));
     $status = $bundle->save();
 
     $t_args = array('%name' => $bundle->label());

--- a/src/MediaBundleForm.php
+++ b/src/MediaBundleForm.php
@@ -98,6 +98,13 @@ class MediaBundleForm extends EntityForm {
       '#description' => t('Describe this media bundle. The text will be displayed on the <em>Add new media</em> page.'),
     );
 
+    $form['new_revision'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Create new revision'),
+      '#default_value' => $bundle->isNewRevision(),
+      '#description' => t('Automatically create a new revision of media entities. Users with the <em>Administer media</em> permission will be able to override this option.'),
+    ];
+
     $plugins = $this->mediaTypeManager->getDefinitions();
     $options = array();
     foreach ($plugins as $plugin => $definition) {
@@ -153,13 +160,6 @@ class MediaBundleForm extends EntityForm {
         '#default_value' => $language_configuration,
       );
     }
-
-    $form['new_revision'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Create new revision'),
-      '#default_value' => $bundle->isNewRevision(),
-      '#description' => t('Automatically create a new revision of media entities. Users with the <em>Administer media</em> permission will be able to override this option.'),
-    ];
 
     return $form;
   }

--- a/src/MediaBundleForm.php
+++ b/src/MediaBundleForm.php
@@ -158,6 +158,7 @@ class MediaBundleForm extends EntityForm {
       '#type' => 'checkbox',
       '#title' => t('Create new revision'),
       '#default_value' => $bundle->isNewRevision(),
+      '#description' => t('Automatically create a new revision of media entities. Users with the <em>Administer media</em> permission will be able to override this option.'),
     ];
 
     return $form;

--- a/src/MediaBundleForm.php
+++ b/src/MediaBundleForm.php
@@ -160,8 +160,8 @@ class MediaBundleForm extends EntityForm {
       '#default_value' => $bundle->isNewRevision(),
     ];
 
-     return $form;
-   }
+    return $form;
+  }
 
   /**
    * {@inheritdoc}

--- a/src/MediaBundleInterface.php
+++ b/src/MediaBundleInterface.php
@@ -67,4 +67,22 @@ interface MediaBundleInterface extends ConfigEntityInterface {
    *   The type configuration.
    */
   public function setTypeConfiguration($configuration);
+
+  /**
+   * Gets whether a new revision should be created by default.
+   *
+   * @return bool
+   *   TRUE if a new revision should be created by default.
+   */
+  public function isNewRevision();
+
+  /**
+   * Sets whether a new revision should be created by default.
+   *
+   * @param bool $new_revision
+   *   TRUE if a new revision should be created by default.
+   */
+  public function setNewRevision($new_revision);
+
+
 }

--- a/src/MediaForm.php
+++ b/src/MediaForm.php
@@ -78,14 +78,14 @@ class MediaForm extends ContentEntityForm {
     $form['revision_information']['revision'] = array(
       '#type' => 'checkbox',
       '#title' => $this->t('Create new revision'),
-      '#default_value' => $media->isNewRevision(),
+      '#default_value' => $media->bundle->entity->isNewRevision(),
       '#access' => $account->hasPermission('administer media'),
     );
 
     // Check the revision log checkbox when the log textarea is filled in.
     // This must not happen if "Create new revision" is enabled by default,
     // since the state would auto-disable the checkbox otherwise.
-    if (!$media->isNewRevision()) {
+    if (!$media->bundle->entity->isNewRevision()) {
       $form['revision_information']['revision']['#states'] = array(
         'checked' => array(
           'textarea[name="revision_log"]' => array('empty' => FALSE),


### PR DESCRIPTION
Allow to automatically select new revision for media entities per bundle.
