### PR TITLE
Issue 2669232: Add support for bulk operations

### DIFF
--- a/config/install/system.action.media_delete_action.yml
+++ b/config/install/system.action.media_delete_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+id: media_delete_action
+label: 'Delete media'
+type: media
+plugin: media_delete_action
+configuration: {  }

--- a/config/install/system.action.media_save_action.yml
+++ b/config/install/system.action.media_save_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+id: media_save_action
+label: 'Save media'
+type: media
+plugin: media_save_action
+configuration: {  }

--- a/config/schema/media_entity.schema.yml
+++ b/config/schema/media_entity.schema.yml
@@ -35,3 +35,11 @@ media_entity.bundle.*:
     field_map:
       type: mapping
       label: 'Field map'
+
+action.configuration.media_delete_action:
+  type: action_configuration_default
+  label: 'Delete media configuration'
+
+action.configuration.media_save_action:
+  type: action_configuration_default
+  label: 'Save media configuration'

--- a/config/schema/media_entity.views.schema.yml
+++ b/config/schema/media_entity.views.schema.yml
@@ -1,0 +1,5 @@
+# Schema for the views plugins of the Media Entity module.
+
+views.field.media_bulk_form:
+  type: views_field_bulk_form
+  label: 'Media Entity bulk form'

--- a/media_entity.routing.yml
+++ b/media_entity.routing.yml
@@ -50,7 +50,7 @@ entity.media.multiple_delete_confirm:
   defaults:
     _form: '\Drupal\media_entity\Form\DeleteMultiple'
   requirements:
-    _permission: 'administer media'
+    _permission: 'delete any media'
 
 entity.media_bundle.collection:
   path: '/admin/structure/media'

--- a/media_entity.routing.yml
+++ b/media_entity.routing.yml
@@ -45,6 +45,13 @@ entity.media.delete_form:
   requirements:
     _entity_access: 'media.delete'
 
+entity.media.multiple_delete_confirm:
+  path: '/admin/content/media/delete'
+  defaults:
+    _form: '\Drupal\media_entity\Form\DeleteMultiple'
+  requirements:
+    _permission: 'administer media'
+
 entity.media_bundle.collection:
   path: '/admin/structure/media'
   defaults:

--- a/src/Form/DeleteMultiple.php
+++ b/src/Form/DeleteMultiple.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\media_entity\Form\DeleteMultiple.
+ */
+
+namespace Drupal\media_entity\Form;
+
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\user\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Provides a media deletion confirmation form.
+ */
+class DeleteMultiple extends ConfirmFormBase {
+
+  /**
+   * The array of media entities to delete.
+   *
+   * @var string[][]
+   */
+  protected $entityInfo = array();
+
+  /**
+   * The tempstore factory.
+   *
+   * @var \Drupal\user\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $manager;
+
+  /**
+   * Constructs a DeleteMultiple form object.
+   *
+   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Entity\EntityManagerInterface $manager
+   *   The entity manager.
+   */
+  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityManagerInterface $manager) {
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->storage = $manager->getStorage('media');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('user.private_tempstore'),
+      $container->get('entity.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'media_multiple_delete_confirm';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->formatPlural(count($this->entityInfo), 'Are you sure you want to delete this item?', 'Are you sure you want to delete these items?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('system.admin_content');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $this->entityInfo = $this->tempStoreFactory->get('media_multiple_delete_confirm')->get(\Drupal::currentUser()->id());
+    if (empty($this->entityInfo)) {
+      return new RedirectResponse($this->getCancelUrl()->setAbsolute()->toString());
+    }
+    /** @var \Drupal\media_entity\MediaInterface[] $entities */
+    $entities = $this->storage->loadMultiple(array_keys($this->entityInfo));
+
+    $items = [];
+    foreach ($this->entityInfo as $id => $langcodes) {
+      foreach ($langcodes as $langcode) {
+        $entity = $entities[$id]->getTranslation($langcode);
+        $key = $id . ':' . $langcode;
+        $default_key = $id . ':' . $entity->getUntranslated()->language()->getId();
+
+        // If we have a translated entity we build a nested list of translations
+        // that will be deleted.
+        $languages = $entity->getTranslationLanguages();
+        if (count($languages) > 1 && $entity->isDefaultTranslation()) {
+          $names = [];
+          foreach ($languages as $translation_langcode => $language) {
+            $names[] = $language->getName();
+            unset($items[$id . ':' . $translation_langcode]);
+          }
+          $items[$default_key] = [
+            'label' => [
+              '#markup' => $this->t('@label (Original translation) - <em>The following media translations will be deleted:</em>', ['@label' => $entity->label()]),
+            ],
+            'deleted_translations' => [
+              '#theme' => 'item_list',
+              '#items' => $names,
+            ],
+          ];
+        }
+        elseif (!isset($items[$default_key])) {
+          $items[$key] = $entity->label();
+        }
+      }
+    }
+
+    $form['entities'] = array(
+      '#theme' => 'item_list',
+      '#items' => $items,
+    );
+    $form = parent::buildForm($form, $form_state);
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if ($form_state->getValue('confirm') && !empty($this->entityInfo)) {
+      $total_count = 0;
+      $delete_entities = [];
+      /** @var \Drupal\Core\Entity\ContentEntityInterface[][] $delete_translations */
+      $delete_translations = [];
+      /** @var \Drupal\media_entity\MediaInterface[] $entities */
+      $entities = $this->storage->loadMultiple(array_keys($this->entityInfo));
+
+      foreach ($this->entityInfo as $id => $langcodes) {
+        foreach ($langcodes as $langcode) {
+          $entity = $entities[$id]->getTranslation($langcode);
+          if ($entity->isDefaultTranslation()) {
+            $delete_entities[$id] = $entity;
+            unset($delete_translations[$id]);
+            $total_count += count($entity->getTranslationLanguages());
+          }
+          elseif (!isset($delete_entities[$id])) {
+            $delete_translations[$id][] = $entity;
+          }
+        }
+      }
+
+      if ($delete_entities) {
+        $this->storage->delete($delete_entities);
+        $this->logger('media_entity')->notice('Deleted @count media entities.', array('@count' => count($delete_entities)));
+      }
+
+      if ($delete_translations) {
+        $count = 0;
+        foreach ($delete_translations as $id => $translations) {
+          $entity = $entities[$id]->getUntranslated();
+          foreach ($translations as $translation) {
+            $entity->removeTranslation($translation->language()->getId());
+          }
+          $entity->save();
+          $count += count($translations);
+        }
+        if ($count) {
+          $total_count += $count;
+          $this->logger('media_entity')->notice('Deleted @count media translations.', array('@count' => $count));
+        }
+      }
+
+      if ($total_count) {
+        drupal_set_message($this->formatPlural($total_count, 'Deleted 1 media entity.', 'Deleted @count media entities.'));
+      }
+
+      $this->tempStoreFactory->get('media_multiple_delete_confirm')->delete(\Drupal::currentUser()->id());
+    }
+
+    $form_state->setRedirect('system.admin_content');
+  }
+
+}

--- a/src/MediaViewsData.php
+++ b/src/MediaViewsData.php
@@ -22,6 +22,13 @@ class MediaViewsData extends EntityViewsData {
 
     $data['media_field_data']['table']['wizard_id'] = 'media';
     $data['media_field_revision']['table']['wizard_id'] = 'media_revision';
+    $data['media']['media_bulk_form'] = array(
+      'title' => t('Media operations bulk form'),
+      'help' => t('Add a form element that lets you run operations on multiple media entities.'),
+      'field' => array(
+        'id' => 'media_bulk_form',
+      ),
+    );
 
     return $data;
   }

--- a/src/Plugin/Action/DeleteMedia.php
+++ b/src/Plugin/Action/DeleteMedia.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\media_entity\Plugin\Action\DeleteMedia.
+ */
+
+namespace Drupal\media_entity\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Redirects to a media deletion form.
+ *
+ * @Action(
+ *   id = "media_delete_action",
+ *   label = @Translation("Delete media"),
+ *   type = "media",
+ *   confirm_form_route_name = "entity.media.multiple_delete_confirm"
+ * )
+ */
+class DeleteMedia extends ActionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The tempstore object.
+   *
+   * @var \Drupal\user\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new DeleteMedia object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param AccountInterface $current_user
+   *   Current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+    $this->tempStore = $temp_store_factory->get('media_multiple_delete_confirm');
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('user.private_tempstore'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities) {
+    $info = [];
+    /** @var \Drupal\media_entity\MediaInterface $media */
+    foreach ($entities as $media) {
+      $langcode = $media->language()->getId();
+      $info[$media->id()][$langcode] = $langcode;
+    }
+    $this->tempStore->set($this->currentUser->id(), $info);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($object = NULL) {
+    $this->executeMultiple(array($object));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\media_entity\MediaInterface $object */
+    return $object->access('delete', $account, $return_as_object);
+  }
+
+}

--- a/src/Plugin/Action/SaveMedia.php
+++ b/src/Plugin/Action/SaveMedia.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\media_entity\Plugin\Action\SaveNode.
+ */
+
+namespace Drupal\media_entity\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides an action that can save any entity.
+ *
+ * @Action(
+ *   id = "media_save_action",
+ *   label = @Translation("Save media"),
+ *   type = "media"
+ * )
+ */
+class SaveMedia extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    // We need to change at least one value, otherwise the changed timestamp
+    // will not be updated.
+    $entity->changed = 0;
+    $entity->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\media_entity\Entity\Media $object */
+    return $object->access('update', $account, $return_as_object);
+  }
+
+}

--- a/src/Plugin/Action/SaveMedia.php
+++ b/src/Plugin/Action/SaveMedia.php
@@ -35,7 +35,7 @@ class SaveMedia extends ActionBase {
    * {@inheritdoc}
    */
   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
-    /** @var \Drupal\media_entity\Entity\Media $object */
+    /** @var \Drupal\media_entity\MediaInterface $object */
     return $object->access('update', $account, $return_as_object);
   }
 

--- a/src/Plugin/views/field/MediaBulkForm.php
+++ b/src/Plugin/views/field/MediaBulkForm.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\media_entity\Plugin\views\field\MediaBulkForm.
+ */
+
+namespace Drupal\media_entity\Plugin\views\field;
+
+use Drupal\system\Plugin\views\field\BulkForm;
+
+/**
+ * Defines a media operations bulk form element.
+ *
+ * @ViewsField("media_bulk_form")
+ */
+class MediaBulkForm extends BulkForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function emptySelectedMessage() {
+    return $this->t('No media selected.');
+  }
+
+}


### PR DESCRIPTION
For https://www.drupal.org/node/2669232

I just stole all this from the node module and adjusted it.

I wasn't sure what to put for the redirect URLs once content has been deleted in DeleteMedia.php, since the View provided in media_entity may be disabled, in which case we wouldn't want to redirect to it. So for the time being I left it to redirect to the core content listing page. Thoughts?
