### PR TITLE
2626376 media bundle configuration use ajax

### DIFF
--- a/src/Plugin/MediaEntity/Type/Generic.php
+++ b/src/Plugin/MediaEntity/Type/Generic.php
@@ -43,4 +43,16 @@ class Generic extends MediaTypeBase {
     return $this->config->get('icon_base') . '/generic.png';
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['text'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('This type provider doesn\'t need configuration.'),
+    ];
+
+    return $form;
+  }
+
 }


### PR DESCRIPTION
Rerolled https://www.drupal.org/node/2626376 (ajax_13.patch) and changed the following:
*Moved buildConfigurationForm() to Generic type
*Fixed call to validatedConfigurationForm() in submitForm(), 
*Changed Generic type placeholder text and ajax message.
*Do not instantiate all plugins in form().
*Persist previous type configuration in form().
