### PR TITLE
ThumbnailDownloader does not handle if a media entity cannot be loaded.

### DIFF
--- a/src/Plugin/QueueWorker/thumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/thumbnailDownloader.php
@@ -20,11 +20,12 @@ class ThumbnailDownloader extends QueueWorkerBase {
    * {@inheritdoc}
    */
   public function processItem($data) {
-    $entity = Media::load($data['id']);
-    // Indicate that the entity is being processed from a queue and that
-    // thumbnail images should be downloaded.
-    $entity->setQueuedThumbnailDownload();
-    $entity->save();
+    if ($entity = Media::load($data['id'])) {
+      // Indicate that the entity is being processed from a queue and that
+      // thumbnail images should be downloaded.
+      $entity->setQueuedThumbnailDownload();
+      $entity->save();
+    }
   }
 
 }


### PR DESCRIPTION
Drupal.org issue: https://www.drupal.org/node/2800945
